### PR TITLE
feature: make auth available in procedure context

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,21 +1,18 @@
+// IMPORTANT: This file MUST be named "middleware" and MUST be placed alongside the ./pages directory.
+
 import { withClerkMiddleware } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
+// Next.js documentation on middleware:
+// https://nextjs.org/docs/advanced-features/middleware
+
 export default withClerkMiddleware(() => {
-  console.log("withClerkMiddleware()");
   return NextResponse.next();
 });
 
+/**
+ * A config that prevents middleware from running on static files.
+ */
 export const config = {
-  matcher: [
-    /*
-     * Match all request paths except for the ones starting with:
-     * - _next
-     * - static (static files)
-     * - favicon.ico (favicon file)
-     * - public folder
-     */
-    "/((?!static|.*\\..*|_next|favicon.ico).*)",
-    "/",
-  ],
+  matcher: "/((?!_next/image|_next/static|favicon.ico).*)",
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,6 +10,7 @@ import { Inter } from "next/font/google";
 const inter = Inter({ subsets: ["latin"] });
 
 const Home: NextPage = () => {
+  // TODO: How do you invalidate a query like this once you've signed in?
   const hello = api.example.hello.useQuery({ text: "from tRPC" });
 
   const { user, isLoaded, isSignedIn } = useUser();
@@ -35,6 +36,7 @@ const Home: NextPage = () => {
           <p>User?.username: {JSON.stringify(user?.fullName)}</p>
           <p>isLoaded: {String(isLoaded)}</p>
           <p>isSignedIn: {String(isSignedIn)}</p>
+          <p>{hello.data?.greeting}</p>
           {user !== null && user !== undefined ? (
             <SignOutButton>
               <button

--- a/src/server/api/routers/example.ts
+++ b/src/server/api/routers/example.ts
@@ -5,9 +5,11 @@ import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
 export const exampleRouter = createTRPCRouter({
   hello: publicProcedure
     .input(z.object({ text: z.string() }))
-    .query(({ input }) => {
+    .query(({ input, ctx }) => {
       return {
-        greeting: `Hello ${input.text}`,
+        greeting: `Hello ${input.text}, you appear to be ${
+          ctx.auth.userId === null ? "signed out" : ctx.auth.userId
+        }.`,
       };
     }),
   getAll: publicProcedure.query(({ ctx }) => {

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -18,7 +18,9 @@ import { type CreateNextContextOptions } from "@trpc/server/adapters/next";
 
 import { prisma } from "~/server/db";
 
-type CreateContextOptions = Record<string, never>;
+type CreateContextOptions = {
+  auth: SignedInAuthObject | SignedOutAuthObject;
+};
 
 /**
  * This helper generates the "internals" for a tRPC context. If you need to use it, you can export
@@ -30,8 +32,9 @@ type CreateContextOptions = Record<string, never>;
  *
  * @see https://create.t3.gg/en/usage/trpc#-serverapitrpcts
  */
-const createInnerTRPCContext = (_opts: CreateContextOptions) => {
+const createInnerTRPCContext = ({ auth }: CreateContextOptions) => {
   return {
+    auth,
     prisma,
   };
 };
@@ -42,8 +45,8 @@ const createInnerTRPCContext = (_opts: CreateContextOptions) => {
  *
  * @see https://trpc.io/docs/context
  */
-export const createTRPCContext = (_opts: CreateNextContextOptions) => {
-  return createInnerTRPCContext({});
+export const createTRPCContext = (opts: CreateNextContextOptions) => {
+  return createInnerTRPCContext({ auth: getAuth(opts.req) });
 };
 
 /**
@@ -56,6 +59,11 @@ export const createTRPCContext = (_opts: CreateNextContextOptions) => {
 import { initTRPC } from "@trpc/server";
 import superjson from "superjson";
 import { ZodError } from "zod";
+import {
+  type SignedInAuthObject,
+  type SignedOutAuthObject,
+} from "@clerk/nextjs/dist/api";
+import { getAuth } from "@clerk/nextjs/server";
 
 const t = initTRPC.context<typeof createTRPCContext>().create({
   transformer: superjson,


### PR DESCRIPTION
Made `auth` available in procedure contexts by following the steps here:
https://clerk.com/docs/nextjs/trpc#using-clerk-in-your-trpc-context

Had to change the middleware matcher because the previous value seemed to be not being used on the root page.
I borrowed the new value from Theo's demo repo:
https://github.com/t3dotgg/chirp/blob/main/src/middleware.ts

To test, I'm just including some auth info in the "hello" api call. It doesn't refetch in response to logging in/out: I guess we need to invalidate that query after a login. One for another PR.