### PR TITLE
Feature: Add privateProcedure method to trpc.ts

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,6 +13,10 @@ const Home: NextPage = () => {
   // TODO: How do you invalidate a query like this once you've signed in?
   const hello = api.example.hello.useQuery({ text: "from tRPC" });
 
+  const strLenPrivate = api.example.stringLengthPrivate.useQuery("thisString", {
+    retry: false,
+  });
+
   const { user, isLoaded, isSignedIn } = useUser();
 
   return (
@@ -37,6 +41,10 @@ const Home: NextPage = () => {
           <p>isLoaded: {String(isLoaded)}</p>
           <p>isSignedIn: {String(isSignedIn)}</p>
           <p>{hello.data?.greeting}</p>
+          <p>
+            strLenPrivate: {strLenPrivate.data}, strLenPrivate.error:{" "}
+            {strLenPrivate.error?.message}
+          </p>
           {user !== null && user !== undefined ? (
             <SignOutButton>
               <button

--- a/src/server/api/routers/example.ts
+++ b/src/server/api/routers/example.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 
-import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
+import {
+  createTRPCRouter,
+  privateProcedure,
+  publicProcedure,
+} from "~/server/api/trpc";
 
 export const exampleRouter = createTRPCRouter({
   hello: publicProcedure
@@ -15,4 +19,9 @@ export const exampleRouter = createTRPCRouter({
   getAll: publicProcedure.query(({ ctx }) => {
     return ctx.prisma.example.findMany();
   }),
+  stringLengthPrivate: privateProcedure
+    .input(z.string())
+    .query(({ input, ctx }) => {
+      return input.length;
+    }),
 });


### PR DESCRIPTION
Issue #3.

Implementing private procedure as described: https://clerk.com/docs/nextjs/trpc#using-trpc-middleware.

Basically the same as in t3.gg demo repo.

Added a simple stringLengthPrivate private query, and called it in the root page. If not signed in, it should return nothing and just display the "unauthorized" error message. Set retry to false so that it just fails once to show how it works.

PR set to draft until #2 is merged.